### PR TITLE
IS-1648: Bugfix empty huskelapp_versjon

### DIFF
--- a/src/main/resources/db/migration/V1_4__bugfix_empty_versjon.sql
+++ b/src/main/resources/db/migration/V1_4__bugfix_empty_versjon.sql
@@ -1,0 +1,2 @@
+ DELETE FROM huskelapp_versjon hv WHERE tekst='' AND EXISTS
+ (SELECT 1 FROM huskelapp_versjon hv2 WHERE hv2.huskelapp_id = hv.huskelapp_id AND hv2.id < hv.id);


### PR DESCRIPTION
Sletter versjonene med tom tekst der det finnes en tidligere versjon