### PR TITLE
IS-1646: Give syfooversiktsrv access to topic

### DIFF
--- a/.nais/kafka/huskelapp.yaml
+++ b/.nais/kafka/huskelapp.yaml
@@ -23,8 +23,5 @@ spec:
       application: ishuskelapp
       access: readwrite
     - team: teamsykefravr
-      application: ispersonoppgave
-      access: read
-    - team: teamsykefravr
       application: syfooversiktsrv
       access: read

--- a/.nais/kafka/huskelapp.yaml
+++ b/.nais/kafka/huskelapp.yaml
@@ -25,3 +25,6 @@ spec:
     - team: teamsykefravr
       application: ispersonoppgave
       access: read
+    - team: teamsykefravr
+      application: syfooversiktsrv
+      access: read


### PR DESCRIPTION
`syfooversiktsrv` står og feiler i dev fordi vi glemte denne :/ 

Skulle jeg fjernet `ispersonoppgave` og?