### PR TITLE
IS-1656: Implement DELETE in huskelapp api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/huskelapp/HuskelappService.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/HuskelappService.kt
@@ -4,12 +4,13 @@ import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.huskelapp.database.HuskelappRepository
 import no.nav.syfo.huskelapp.database.PHuskelapp
 import no.nav.syfo.huskelapp.domain.Huskelapp
+import java.util.*
 
 class HuskelappService(
     private val huskelappRepository: HuskelappRepository,
 ) {
     fun getHuskelapp(personIdent: PersonIdent): Huskelapp? =
-        huskelappRepository.getHuskelapper(personIdent).firstOrNull()?.toHuskelapp()
+        huskelappRepository.getHuskelapper(personIdent).firstOrNull()?.takeIf { it.isActive }?.toHuskelapp()
 
     fun createHuskelapp(
         personIdent: PersonIdent,
@@ -38,6 +39,17 @@ class HuskelappService(
     fun getUnpublishedHuskelapper(): List<Huskelapp> = huskelappRepository.getUnpublished().map { it.toHuskelapp() }
 
     fun setPublished(huskelapp: Huskelapp) = huskelappRepository.setPublished(huskelapp = huskelapp)
+
+    fun getHuskelapp(uuid: UUID): Huskelapp? =
+        huskelappRepository.getHuskelapp(uuid)?.takeIf { it.isActive }?.toHuskelapp()
+
+    fun removeHuskelapp(
+        huskelapp: Huskelapp,
+        veilederIdent: String,
+    ) {
+        val removedHuskelapp = huskelapp.remove(veilederIdent = veilederIdent)
+        huskelappRepository.updateRemovedHuskelapp(huskelapp = removedHuskelapp)
+    }
 
     private fun PHuskelapp.toHuskelapp(): Huskelapp {
         val huskelappVersjon = huskelappRepository.getHuskelappVersjoner(this.id).first()

--- a/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappApi.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappApi.kt
@@ -12,8 +12,10 @@ import no.nav.syfo.huskelapp.HuskelappService
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.getNAVIdent
 import no.nav.syfo.util.getPersonIdent
+import java.util.*
 
 const val huskelappApiBasePath = "/api/internad/v1/huskelapp"
+const val huskelappParam = "huskelappUuid"
 
 private const val API_ACTION = "access huskelapp for person"
 
@@ -43,7 +45,6 @@ fun Route.registerHuskelappApi(
                 call.respond(responseDTO)
             }
         }
-
         post {
             val personIdent = call.personIdent()
             val requestDTO = call.receive<HuskelappRequestDTO>()
@@ -56,6 +57,18 @@ fun Route.registerHuskelappApi(
             )
 
             call.respond(HttpStatusCode.Created)
+        }
+        delete("/{$huskelappParam}") {
+            val huskelappUuid = UUID.fromString(call.parameters[huskelappParam])
+            val veilederIdent = call.getNAVIdent()
+
+            val huskelapp = huskelappService.getHuskelapp(uuid = huskelappUuid)
+            if (huskelapp == null) {
+                call.respond(HttpStatusCode.NotFound)
+            } else {
+                huskelappService.removeHuskelapp(huskelapp = huskelapp, veilederIdent = veilederIdent)
+                call.respond(HttpStatusCode.NoContent)
+            }
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/huskelapp/cronjob/PublishHuskelappCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/huskelapp/cronjob/PublishHuskelappCronjobSpek.kt
@@ -49,7 +49,7 @@ class PublishHuskelappCronjobSpek : Spek({
             database.dropData()
         }
 
-        it("publishes unpublished huskelapper") {
+        it("publishes unpublished huskelapper oldest first") {
             val enHuskelapp = Huskelapp.create("En huskelapp", personIdent, veilederIdent)
             val annenHuskelapp = Huskelapp.create("Annen huskelapp", personIdent, veilederIdent)
             listOf(enHuskelapp, annenHuskelapp).forEach {
@@ -68,10 +68,7 @@ class PublishHuskelappCronjobSpek : Spek({
                 kafkaProducer.send(capture(kafkaRecordSlot2))
             }
 
-            val enKafkaHuskelapp = listOf(
-                kafkaRecordSlot1.captured.value(),
-                kafkaRecordSlot2.captured.value()
-            ).first { it.uuid == enHuskelapp.uuid }
+            val enKafkaHuskelapp = kafkaRecordSlot1.captured.value()
 
             enKafkaHuskelapp.tekst shouldBeEqualTo enHuskelapp.tekst
             enKafkaHuskelapp.personIdent shouldBeEqualTo enHuskelapp.personIdent.value


### PR DESCRIPTION
Implementert API som kan brukes av syfomodiaperson til å fjerne aktiv huskelapp på en person.
Følte det ble mest riktig med DELETE-metode her - trenger bare uuid i urlen og ingen body. Dette krever litt ekstra tilpasning i frontend siden vi bare har implementert GET og POST i axios der.