### PR TITLE
IS-1822: Add oppfolgingsgrunner column to huskelapp_versjon table

### DIFF
--- a/src/main/resources/db/migration/V1_7__add_huskelapp_oppfolgningsgrunner.sql
+++ b/src/main/resources/db/migration/V1_7__add_huskelapp_oppfolgningsgrunner.sql
@@ -1,0 +1,2 @@
+ALTER TABLE HUSKELAPP_VERSJON
+    ADD COLUMN oppfolgingsgrunner TEXT;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til migrerringsscript som støtter `oppfolgingsgrunner`.
- I utgangspunktet skal bruker bare kunne velge én oppfølgingsgrunn, men tenkte at vi ikke ville utelukke at de skal kunne sende inn flere så derfor namingen: `oppfolgingsgrunner`. Tanker om dette? 😊