### PR TITLE
IS-1710: Use frist

### DIFF
--- a/src/main/kotlin/no/nav/syfo/huskelapp/HuskelappService.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/HuskelappService.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.huskelapp.database.HuskelappRepository
 import no.nav.syfo.huskelapp.database.PHuskelapp
 import no.nav.syfo.huskelapp.domain.Huskelapp
+import java.time.LocalDate
 import java.util.*
 
 class HuskelappService(
@@ -22,16 +23,18 @@ class HuskelappService(
         personIdent: PersonIdent,
         veilederIdent: String,
         tekst: String,
+        frist: LocalDate?,
     ) {
         val huskelapp = huskelappRepository.getHuskelapper(personIdent).firstOrNull()
 
         if (huskelapp?.isActive == true) {
             val huskelappVersjon = huskelappRepository.getHuskelappVersjoner(huskelapp.id).first()
-            if (!tekst.equals(huskelappVersjon.tekst)) {
+            if (tekst != huskelappVersjon.tekst) {
                 huskelappRepository.createVersjon(
                     huskelappId = huskelapp.id,
                     veilederIdent = veilederIdent,
                     tekst = tekst,
+                    frist = frist,
                 )
                 COUNT_HUSKELAPP_VERSJON_CREATED.increment()
             }
@@ -39,6 +42,7 @@ class HuskelappService(
             huskelappRepository.create(
                 huskelapp = Huskelapp.create(
                     tekst = tekst,
+                    frist = frist,
                     personIdent = personIdent,
                     veilederIdent = veilederIdent,
                 )

--- a/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappApi.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappApi.kt
@@ -41,6 +41,7 @@ fun Route.registerHuskelappApi(
                     createdBy = huskelapp.createdBy,
                     updatedAt = huskelapp.updatedAt,
                     tekst = huskelapp.tekst,
+                    frist = huskelapp.frist,
                 )
 
                 call.respond(responseDTO)
@@ -55,6 +56,7 @@ fun Route.registerHuskelappApi(
                 personIdent = personIdent,
                 veilederIdent = veilederIdent,
                 tekst = requestDTO.tekst,
+                frist = requestDTO.frist,
             )
 
             call.respond(HttpStatusCode.Created)

--- a/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappDTO.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.huskelapp.api
 
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 data class HuskelappRequestDTO(
     val tekst: String,
+    val frist: LocalDate? = null,
 )
 
 data class HuskelappResponseDTO(
@@ -11,4 +13,5 @@ data class HuskelappResponseDTO(
     val createdBy: String,
     val updatedAt: OffsetDateTime,
     val tekst: String,
+    val frist: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/syfo/huskelapp/database/PHuskelapp.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/database/PHuskelapp.kt
@@ -26,6 +26,7 @@ data class PHuskelapp(
             updatedAt = pHuskelappVersjon.createdAt,
             publishedAt = publishedAt,
             removedBy = removedBy,
+            frist = pHuskelappVersjon.frist,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/huskelapp/database/PHuskelappVersjon.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/database/PHuskelappVersjon.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.huskelapp.database
 
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -10,4 +11,5 @@ data class PHuskelappVersjon(
     val createdAt: OffsetDateTime,
     val createdBy: String,
     val tekst: String,
+    val frist: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/syfo/huskelapp/domain/Huskelapp.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/domain/Huskelapp.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.huskelapp.domain
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.util.nowUTC
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -10,6 +11,7 @@ data class Huskelapp private constructor(
     val personIdent: PersonIdent,
     val createdBy: String,
     val tekst: String,
+    val frist: LocalDate?,
     val isActive: Boolean,
     val createdAt: OffsetDateTime,
     val updatedAt: OffsetDateTime,
@@ -21,6 +23,7 @@ data class Huskelapp private constructor(
             tekst: String,
             personIdent: PersonIdent,
             veilederIdent: String,
+            frist: LocalDate? = null,
         ): Huskelapp {
             val now = nowUTC()
             return Huskelapp(
@@ -28,6 +31,7 @@ data class Huskelapp private constructor(
                 personIdent = personIdent,
                 createdBy = veilederIdent,
                 tekst = tekst,
+                frist = frist,
                 isActive = true,
                 createdAt = now,
                 updatedAt = now,
@@ -41,6 +45,7 @@ data class Huskelapp private constructor(
             personIdent: PersonIdent,
             veilederIdent: String,
             tekst: String,
+            frist: LocalDate?,
             isActive: Boolean,
             createdAt: OffsetDateTime,
             updatedAt: OffsetDateTime,
@@ -51,6 +56,7 @@ data class Huskelapp private constructor(
             personIdent = personIdent,
             createdBy = veilederIdent,
             tekst = tekst,
+            frist = frist,
             isActive = isActive,
             createdAt = createdAt,
             updatedAt = updatedAt,

--- a/src/main/kotlin/no/nav/syfo/huskelapp/kafka/HuskelappProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/kafka/HuskelappProducer.kt
@@ -22,6 +22,7 @@ class HuskelappProducer(
             isActive = huskelapp.isActive,
             createdAt = huskelapp.createdAt,
             updatedAt = huskelapp.updatedAt,
+            frist = huskelapp.frist,
         )
         val key = UUID.nameUUIDFromBytes(kafkaHuskelapp.personIdent.toByteArray()).toString()
         try {

--- a/src/main/kotlin/no/nav/syfo/huskelapp/kafka/KafkaHuskelapp.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/kafka/KafkaHuskelapp.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.huskelapp.kafka
 
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -8,6 +9,7 @@ data class KafkaHuskelapp(
     val personIdent: String,
     val veilederIdent: String,
     val tekst: String,
+    val frist: LocalDate?,
     val isActive: Boolean,
     val createdAt: OffsetDateTime,
     val updatedAt: OffsetDateTime,

--- a/src/test/kotlin/no/nav/syfo/huskelapp/api/HuskelappApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/huskelapp/api/HuskelappApiSpek.kt
@@ -14,6 +14,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
 import java.util.*
 
 class HuskelappApiSpek : Spek({
@@ -108,6 +109,7 @@ class HuskelappApiSpek : Spek({
                 describe("Happy path") {
                     val requestDTO = HuskelappRequestDTO(
                         tekst = "Hei",
+                        frist = LocalDate.now().plusDays(1)
                     )
                     it("OK") {
                         with(
@@ -132,6 +134,7 @@ class HuskelappApiSpek : Spek({
                                 objectMapper.readValue<HuskelappResponseDTO>(response.content!!)
 
                             responseDTO.tekst shouldBeEqualTo requestDTO.tekst
+                            responseDTO.frist shouldBeEqualTo requestDTO.frist
                             responseDTO.createdBy shouldBeEqualTo UserConstants.VEILEDER_IDENT
                         }
                     }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til valgfritt frist-dato-felt på API-dtoer og database-objekter og tar det i bruk i domene. Returnerer frist i respons fra APIet slik at den kan vises i `syfomodiaperson` og ut på kafka slik at det kan brukes av `syfooversiktsrv` til å vise fristen i `syfooversikt`.