### PR TITLE
IS-2043: Add endpoint for creating a new oppfolgingsoppgave version

### DIFF
--- a/src/main/kotlin/no/nav/syfo/huskelapp/api/EditedOppfolgingsoppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/api/EditedOppfolgingsoppgaveDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.huskelapp.api
+
+import java.time.LocalDate
+
+data class EditedOppfolgingsoppgaveDTO(
+    val tekst: String?,
+    val frist: LocalDate,
+)

--- a/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/api/HuskelappDTO.kt
@@ -1,11 +1,12 @@
 package no.nav.syfo.huskelapp.api
 
+import no.nav.syfo.huskelapp.domain.Huskelapp
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class HuskelappRequestDTO(
     val tekst: String?,
-    val oppfolgingsgrunn: String?,
+    val oppfolgingsgrunn: String,
     val frist: LocalDate? = null,
 )
 
@@ -17,4 +18,17 @@ data class HuskelappResponseDTO(
     val tekst: String?,
     val oppfolgingsgrunn: String?,
     val frist: LocalDate?,
-)
+) {
+    companion object {
+        fun fromOppfolgingsoppgave(oppfolgingsoppgave: Huskelapp) =
+            HuskelappResponseDTO(
+                uuid = oppfolgingsoppgave.uuid.toString(),
+                createdBy = oppfolgingsoppgave.createdBy,
+                updatedAt = oppfolgingsoppgave.updatedAt.toLocalDateTime(),
+                createdAt = oppfolgingsoppgave.createdAt.toLocalDateTime(),
+                tekst = oppfolgingsoppgave.tekst,
+                oppfolgingsgrunn = oppfolgingsoppgave.oppfolgingsgrunner.first(),
+                frist = oppfolgingsoppgave.frist,
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/huskelapp/domain/Huskelapp.kt
+++ b/src/main/kotlin/no/nav/syfo/huskelapp/domain/Huskelapp.kt
@@ -19,6 +19,10 @@ data class Huskelapp private constructor(
     val publishedAt: OffsetDateTime?,
     val removedBy: String?,
 ) {
+
+    fun edit(frist: LocalDate): Huskelapp =
+        this.copy(frist = frist, updatedAt = nowUTC())
+
     companion object {
         fun create(
             personIdent: PersonIdent,

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -2,7 +2,5 @@ package no.nav.syfo.util
 
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
-const val TEMA_HEADER = "Tema"
-const val ALLE_TEMA_HEADERVERDI = "GEN"
 
 fun bearerHeader(token: String) = "Bearer $token"

--- a/src/test/kotlin/no/nav/syfo/application/HuskelappServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/HuskelappServiceSpek.kt
@@ -1,0 +1,76 @@
+package no.nav.syfo.application
+
+import no.nav.syfo.huskelapp.HuskelappService
+import no.nav.syfo.huskelapp.api.EditedOppfolgingsoppgaveDTO
+import no.nav.syfo.huskelapp.database.HuskelappRepository
+import no.nav.syfo.huskelapp.domain.Huskelapp
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.dropData
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+
+class HuskelappServiceSpek : Spek({
+
+    describe(HuskelappService::class.java.simpleName) {
+
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+
+        val oppfolgingsoppgaveRepository = HuskelappRepository(database = database)
+        val oppfolgingsoppgaveService = HuskelappService(oppfolgingsoppgaveRepository)
+
+        val oppfolgingsoppgave = Huskelapp.create(
+            personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+            veilederIdent = UserConstants.VEILEDER_IDENT,
+            tekst = "En god tekst for en oppfolgingsoppgave",
+            oppfolgingsgrunner = listOf("TA_KONTAKT_SYKEMELDT"),
+            frist = LocalDate.now().plusDays(1),
+        )
+
+        afterEachTest {
+            database.dropData()
+        }
+
+        describe("addVersion") {
+            it("adds a new version of oppfolgingsoppgave with only edited frist") {
+                val newFrist = oppfolgingsoppgave.frist!!.plusWeeks(1)
+                val createdOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
+                val newOppfolgingsoppgaveVersion = EditedOppfolgingsoppgaveDTO(
+                    tekst = oppfolgingsoppgave.tekst,
+                    frist = newFrist,
+                )
+                val newOppfolgingsoppgave = oppfolgingsoppgaveService.addVersion(
+                    existingOppfolgingsoppgaveUuid = createdOppfolgingsoppgave.uuid,
+                    newVersion = newOppfolgingsoppgaveVersion
+                )
+
+                newOppfolgingsoppgave?.uuid shouldBeEqualTo createdOppfolgingsoppgave.uuid
+                newOppfolgingsoppgave?.personIdent shouldBeEqualTo createdOppfolgingsoppgave.personIdent
+                newOppfolgingsoppgave?.createdBy shouldBeEqualTo createdOppfolgingsoppgave.createdBy
+                newOppfolgingsoppgave?.tekst shouldBeEqualTo createdOppfolgingsoppgave.tekst
+                newOppfolgingsoppgave?.oppfolgingsgrunner shouldBeEqualTo createdOppfolgingsoppgave.oppfolgingsgrunner
+                newOppfolgingsoppgave?.isActive shouldBeEqualTo createdOppfolgingsoppgave.isActive
+                newOppfolgingsoppgave?.createdAt shouldBeEqualTo createdOppfolgingsoppgave.createdAt
+                newOppfolgingsoppgave?.publishedAt shouldBeEqualTo createdOppfolgingsoppgave.publishedAt
+                newOppfolgingsoppgave?.removedBy shouldBeEqualTo createdOppfolgingsoppgave.removedBy
+
+                newOppfolgingsoppgave?.uuid shouldBeEqualTo oppfolgingsoppgave.uuid
+                newOppfolgingsoppgave?.personIdent shouldBeEqualTo oppfolgingsoppgave.personIdent
+                newOppfolgingsoppgave?.createdBy shouldBeEqualTo oppfolgingsoppgave.createdBy
+                newOppfolgingsoppgave?.tekst shouldBeEqualTo oppfolgingsoppgave.tekst
+                newOppfolgingsoppgave?.oppfolgingsgrunner shouldBeEqualTo oppfolgingsoppgave.oppfolgingsgrunner
+                newOppfolgingsoppgave?.isActive shouldBeEqualTo oppfolgingsoppgave.isActive
+                newOppfolgingsoppgave?.publishedAt shouldBeEqualTo oppfolgingsoppgave.publishedAt
+                newOppfolgingsoppgave?.removedBy shouldBeEqualTo oppfolgingsoppgave.removedBy
+
+                newOppfolgingsoppgave?.frist shouldNotBeEqualTo createdOppfolgingsoppgave.frist
+                createdOppfolgingsoppgave.frist shouldBeEqualTo oppfolgingsoppgave.frist
+                newOppfolgingsoppgave?.frist shouldBeEqualTo newFrist
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/infrastructure/OppfolgingsoppgaveRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/OppfolgingsoppgaveRepositorySpek.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.infrastructure
+
+import no.nav.syfo.huskelapp.database.HuskelappRepository
+import no.nav.syfo.huskelapp.domain.Huskelapp
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.dropData
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+
+class OppfolgingsoppgaveRepositorySpek : Spek({
+
+    describe(HuskelappRepository::class.java.simpleName) {
+
+        val database = ExternalMockEnvironment.instance.database
+        val oppfolgingsoppgaveRepository = HuskelappRepository(database = database)
+
+        val oppfolgingsoppgave = Huskelapp.create(
+            personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+            veilederIdent = UserConstants.VEILEDER_IDENT,
+            tekst = "En god tekst for en oppfolgingsoppgave",
+            oppfolgingsgrunner = listOf("TA_KONTAKT_SYKEMELDT"),
+            frist = LocalDate.now().plusDays(1),
+        )
+
+        afterEachTest {
+            database.dropData()
+        }
+
+        describe("create") {
+            it("creates an oppfolgingsoppgave") {
+                val createdOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
+                val retrievedOppfolgingsoppgave =
+                    oppfolgingsoppgaveRepository.getHuskelapp(createdOppfolgingsoppgave.uuid)
+
+                createdOppfolgingsoppgave.uuid shouldBeEqualTo retrievedOppfolgingsoppgave?.uuid
+                createdOppfolgingsoppgave.personIdent shouldBeEqualTo retrievedOppfolgingsoppgave?.personIdent
+                createdOppfolgingsoppgave.createdAt shouldBeEqualTo retrievedOppfolgingsoppgave?.createdAt
+                createdOppfolgingsoppgave.isActive shouldBeEqualTo retrievedOppfolgingsoppgave?.isActive
+                createdOppfolgingsoppgave.publishedAt shouldBeEqualTo retrievedOppfolgingsoppgave?.publishedAt
+                createdOppfolgingsoppgave.removedBy shouldBeEqualTo retrievedOppfolgingsoppgave?.removedBy
+            }
+        }
+
+        describe("createVersion") {
+            it("creates a new version of oppfolgingsoppgave with new frist") {
+                val newFrist = LocalDate.now().plusWeeks(1)
+                val createdOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
+                val createdOppfolgingsoppgaveId =
+                    oppfolgingsoppgaveRepository.getHuskelapp(createdOppfolgingsoppgave.uuid)!!.id
+                val newVersion = oppfolgingsoppgave.edit(newFrist)
+                oppfolgingsoppgaveRepository.createVersion(
+                    createdOppfolgingsoppgaveId,
+                    newOppfolgingsoppgaveVersion = newVersion,
+                )
+
+                val oppfolgingsoppgaveVersions =
+                    oppfolgingsoppgaveRepository.getHuskelappVersjoner(createdOppfolgingsoppgaveId)
+
+                oppfolgingsoppgaveVersions.size shouldBe 2
+                oppfolgingsoppgaveVersions[1].frist shouldBeEqualTo oppfolgingsoppgave.frist
+                oppfolgingsoppgaveVersions[0].frist shouldBeEqualTo newFrist
+            }
+        }
+    }
+})


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til endepunkt for å lage ny versjon av oppfølgingsoppgave.
- Litt mye `huskelapp` og `oppfolgingsoppgave` om hverandre her. Kan følge opp med en PR for å rename servicer og repositories.
- Også litt usikker på hvor mye av versjoneringen vi skal ha i domenet🤔 Når det kommer til persistens objektene synes jeg at `pHuskelapp` bør inneholde alle versjoner slik at dette er direkte tilgjengelig. Kan refaktorere dette også på et senere tidspunkt.
- La til api, database og service tester.

Se [tilhørende PR](https://github.com/navikt/syfomodiaperson/pull/1250) i `syfomodiaperson`