### PR TITLE
IS-2199: Update oppfolgingsgrunn where missing

### DIFF
--- a/src/main/resources/db/migration/V1_9__update_opppfolgingsgrunn_where_empty.sql
+++ b/src/main/resources/db/migration/V1_9__update_opppfolgingsgrunn_where_empty.sql
@@ -1,0 +1,11 @@
+UPDATE huskelapp
+SET updated_at = now()
+FROM huskelapp_versjon hv
+WHERE hv.oppfolgingsgrunner IS NULL;
+
+UPDATE huskelapp_versjon
+SET oppfolgingsgrunner = 'ANNET'
+WHERE oppfolgingsgrunner IS NULL;
+
+ALTER TABLE huskelapp_versjon
+    ALTER COLUMN oppfolgingsgrunner SET NOT NULL;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Dette gjelder de gamle oppfølgingsgrunnene som vi brukte i piloten. Tanken med å oppdatere de gamle er at vi ikke trenger å forholde oss til å være bakoverkompatible for dette datapunktet fremover. Det er 346 slike rader, hvorav 22 fortsatt er aktive lapper i dag. Ved å gjøre dette kan vi enforce non-null i databasen og etterhver rundt omkring i koden. Kan skrive en egen PR som oppdaterer non-null i koden også, men tenkte det var fint å skille sånn at bugen blir fikset fortest mulig.