### PR TITLE
IS-2465: Get huskelapp and newest versjon in same db-bulk-query

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/IOppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IOppfolgingsoppgaveRepository.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 interface IOppfolgingsoppgaveRepository {
     fun getOppfolgingsoppgaver(personIdent: PersonIdent): List<POppfolgingsoppgave>
-    fun getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<POppfolgingsoppgave>
+    fun getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<Pair<POppfolgingsoppgave, POppfolgingsoppgaveVersjon>>
     fun getOppfolgingsoppgave(uuid: UUID): POppfolgingsoppgave?
     fun getOppfolgingsoppgaveVersjoner(oppfolgingsoppgaveId: Int): List<POppfolgingsoppgaveVersjon>
     fun create(oppfolgingsoppgave: Oppfolgingsoppgave): Oppfolgingsoppgave

--- a/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt
@@ -22,7 +22,7 @@ class OppfolgingsoppgaveService(
 
     fun getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<Oppfolgingsoppgave> =
         oppfolgingsoppgaveRepository.getActiveOppfolgingsoppgaver(personidenter)
-            .map { it.toOppfolgingsoppgave() }
+            .map { it.first.toOppfolgingsoppgave(pOppfolgingsoppgaveVersjon = it.second) }
 
     fun createOppfolgingsoppgave(
         personIdent: PersonIdent,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Problemet var at vi hentet ut alle oppfølgingsoppgaver, og deretter loopet over og hentet ut `versjoner.first()` for hver av disse. Henter nå nyeste versjon per huskelapp i samme bulk-spørring. Litt komplisert spørring, men man finner altså den nyeste `created_at` på en versjon per huskelapp, og joiner denne med `huskelapp`. God hjelp fra copilot der 🫡