### PR TITLE
IS-2460: Fikset egen håndtering av request parameter isActive

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsoppgaveApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsoppgaveApi.kt
@@ -39,7 +39,17 @@ fun Route.registerOppfolgingsoppgaveApi(
                         OppfolgingsoppgaveNewResponseDTO.fromOppfolgingsoppgaveNew(it)
                     }
                     call.respond(responseDTO)
-                } else if (filter == null || isActive) {
+                } else if (isActive) {
+                    val oppfolgingsoppgave =
+                        oppfolgingsoppgaveService.getOppfolgingsoppgaver(personIdent).firstOrNull { it.isActive }
+
+                    if (oppfolgingsoppgave == null) {
+                        call.respond(HttpStatusCode.NoContent)
+                    } else {
+                        val responseDTO = OppfolgingsoppgaveNewResponseDTO.fromOppfolgingsoppgaveNew(oppfolgingsoppgave)
+                        call.respond(responseDTO)
+                    }
+                } else if (filter == null) {
                     val oppfolgingsoppgave = oppfolgingsoppgaveService.getOppfolgingsoppgave(personIdent)
 
                     if (oppfolgingsoppgave == null) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Glemte å legge til egen håndtering ved bruk av `isActive=true` som er nødvendig før [PR om refaktorering i frontend](https://github.com/navikt/syfomodiaperson/pull/1557) kan merges inn.