### PR TITLE
IS-2460: Lagt til nytt endepunkt for henting av aktive oppfølgingsoppgaver basert på ny datamodell

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/model/OppfolgingsoppgaverDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/OppfolgingsoppgaverDTO.kt
@@ -7,3 +7,7 @@ data class OppfolgingsoppgaverRequestDTO(
 data class OppfolgingsoppgaverResponseDTO(
     val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveResponseDTO>
 )
+
+data class OppfolgingsoppgaverNewResponseDTO(
+    val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveNewResponseDTO>
+)

--- a/src/main/kotlin/no/nav/syfo/application/IOppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IOppfolgingsoppgaveRepository.kt
@@ -9,6 +9,7 @@ interface IOppfolgingsoppgaveRepository {
     fun getPOppfolgingsoppgaver(personIdent: PersonIdent): List<POppfolgingsoppgave>
     fun getOppfolgingsoppgaverNew(personIdent: PersonIdent): List<OppfolgingsoppgaveNew>
     fun getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<Pair<POppfolgingsoppgave, POppfolgingsoppgaveVersjon>>
+    fun getActiveOppfolgingsoppgaverNew(personidenter: List<PersonIdent>): List<OppfolgingsoppgaveNew>
     fun getPOppfolgingsoppgave(uuid: UUID): POppfolgingsoppgave?
     fun getOppfolgingsoppgaveNew(uuid: UUID): OppfolgingsoppgaveNew?
     fun getOppfolgingsoppgaveVersjoner(oppfolgingsoppgaveId: Int): List<POppfolgingsoppgaveVersjon>

--- a/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt
@@ -25,6 +25,9 @@ class OppfolgingsoppgaveService(
         oppfolgingsoppgaveRepository.getActiveOppfolgingsoppgaver(personidenter)
             .map { it.first.toOppfolgingsoppgave(pOppfolgingsoppgaveVersjon = it.second) }
 
+    fun getActiveOppfolgingsoppgaverNew(personidenter: List<PersonIdent>): List<OppfolgingsoppgaveNew> =
+        oppfolgingsoppgaveRepository.getActiveOppfolgingsoppgaverNew(personidenter)
+
     fun getOppfolgingsoppgaver(personIdent: PersonIdent): List<OppfolgingsoppgaveNew> =
         oppfolgingsoppgaveRepository.getOppfolgingsoppgaverNew(personIdent)
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
@@ -32,6 +32,9 @@ class OppfolgingsoppgaveRepository(
     override fun getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<Pair<POppfolgingsoppgave, POppfolgingsoppgaveVersjon>> =
         database.getActiveOppfolgingsoppgaver(personidenter)
 
+    override fun getActiveOppfolgingsoppgaverNew(personidenter: List<PersonIdent>): List<OppfolgingsoppgaveNew> =
+        database.getActiveOppfolgingsoppgaverNew(personidenter)
+
     override fun getPOppfolgingsoppgave(uuid: UUID): POppfolgingsoppgave? {
         return database.getPOppfolgingsoppgave(uuid)
     }
@@ -311,6 +314,27 @@ private fun DatabaseInterface.getActiveOppfolgingsoppgaver(personidenter: List<P
                         toPOppfolgingsoppgaveVersjon(
                             col_name_prefix = "versjon_",
                         ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun DatabaseInterface.getActiveOppfolgingsoppgaverNew(personidenter: List<PersonIdent>): List<OppfolgingsoppgaveNew> {
+    return if (personidenter.isEmpty()) {
+        emptyList()
+    } else {
+        connection.use { connection ->
+            connection.prepareStatement(queryGetActiveOppfolgingsoppgaverByPersonident).use { preparedStatement ->
+                preparedStatement.setString(1, personidenter.joinToString(",") { it.value })
+                preparedStatement.executeQuery().toList {
+                    toPOppfolgingsoppgave().toOppfolgingsoppgaveNew(
+                        listOf(
+                            toPOppfolgingsoppgaveVersjon(
+                                col_name_prefix = "versjon_",
+                            )
+                        )
                     )
                 }
             }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til nytt endepunkt for å hente aktive oppfølgingsoppgaver for flere personer basert på ny datamodell. Denne skal tas i bruk av `syfooversiktsrv` (Skal opprette en PR snart for tilpasning i det repoet).

Tanken er at etter at `syfooversiktsrv` har gått over til det nye endepunktet så vil det komme en siste PR ifm. denne refaktoreringen i `ishuskelapp` for å rydde unna gamle typer helt.