### PR TITLE
IS-2790: Tillate endring av oppfolgingsgrunn

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsoppgaveApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsoppgaveApi.kt
@@ -62,7 +62,9 @@ fun Route.registerOppfolgingsoppgaveApi(
                 val oppfolgingsoppgave = oppfolgingsoppgaveService.createOppfolgingsoppgave(
                     personIdent = personIdent,
                     veilederIdent = veilederIdent,
-                    newOppfolgingsoppgave = requestDTO,
+                    oppfolgingsgrunn = requestDTO.oppfolgingsgrunn,
+                    tekst = requestDTO.tekst,
+                    frist = requestDTO.frist,
                 )
                 call.respond(HttpStatusCode.Created, oppfolgingsoppgave)
             }
@@ -80,6 +82,7 @@ fun Route.registerOppfolgingsoppgaveApi(
                 oppfolgingsoppgaveService.editOppfolgingsoppgave(
                     existingOppfolgingsoppgaveUuid = uuid,
                     veilederIdent = veilederIdent,
+                    newOppfolgingsgrunn = requestDTO.oppfolgingsgrunn,
                     newTekst = requestDTO.tekst,
                     newFrist = requestDTO.frist,
                 )

--- a/src/main/kotlin/no/nav/syfo/api/model/EditedOppfolgingsoppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/EditedOppfolgingsoppgaveDTO.kt
@@ -1,8 +1,10 @@
 package no.nav.syfo.api.model
 
+import no.nav.syfo.domain.Oppfolgingsgrunn
 import java.time.LocalDate
 
 data class EditedOppfolgingsoppgaveDTO(
+    val oppfolgingsgrunn: Oppfolgingsgrunn?,
     val tekst: String?,
     val frist: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/Metric.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/Metric.kt
@@ -28,3 +28,9 @@ val COUNT_HUSKELAPP_REMOVED: Counter =
     Counter.builder(HUSKELAPP_REMOVED)
         .description("Counts the number of huskelapp removed")
         .register(METRICS_REGISTRY)
+
+const val OPPFOLGINGSOPPGAVE_OPPFOLGINGSGRUNN_EDITED = "${METRICS_NS}_oppfolgingsoppgave_oppfolgingsgrunn_edited_count"
+val COUNT_OPPFOLGINGSOPPGAVE_OPPFOLGINGSGRUNN_EDITED: Counter =
+    Counter.builder(OPPFOLGINGSOPPGAVE_OPPFOLGINGSGRUNN_EDITED)
+        .description("Counts the number of oppfolgingsoppgave oppfolgingsgrunn edited")
+        .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/application/OppfolgingsoppgaveServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/OppfolgingsoppgaveServiceSpek.kt
@@ -8,10 +8,7 @@ import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.testhelper.dropData
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeGreaterThan
-import org.amshove.kluent.shouldBeNull
-import org.amshove.kluent.shouldNotBeEqualTo
+import org.amshove.kluent.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
@@ -45,23 +42,25 @@ class OppfolgingsoppgaveServiceSpek : Spek({
                 val publishedOppfolgingsoppgave = createdOppfolgingsoppgave.publish()
                 oppfolgingsoppgaveRepository.updatePublished(publishedOppfolgingsoppgave)
 
-                val newFrist = oppfolgingsoppgave.sisteVersjon().frist!!.plusWeeks(1)
+                val sisteVersjon = oppfolgingsoppgave.sisteVersjon()
+                val newFrist = sisteVersjon.frist!!.plusWeeks(1)
                 val newOppfolgingsoppgave = oppfolgingsoppgaveService.editOppfolgingsoppgave(
                     existingOppfolgingsoppgaveUuid = createdOppfolgingsoppgave.uuid,
                     veilederIdent = UserConstants.OTHER_VEILEDER_IDENT,
-                    newTekst = oppfolgingsoppgave.sisteVersjon().tekst,
+                    newOppfolgingsgrunn = sisteVersjon.oppfolgingsgrunn,
+                    newTekst = sisteVersjon.tekst,
                     newFrist = newFrist,
                 )
 
                 newOppfolgingsoppgave?.uuid shouldBeEqualTo oppfolgingsoppgave.uuid
                 newOppfolgingsoppgave?.personIdent shouldBeEqualTo oppfolgingsoppgave.personIdent
                 newOppfolgingsoppgave?.sisteVersjon()?.createdBy shouldBeEqualTo UserConstants.OTHER_VEILEDER_IDENT
-                newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldBeEqualTo oppfolgingsoppgave.sisteVersjon().tekst
-                newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo oppfolgingsoppgave.sisteVersjon().oppfolgingsgrunn
+                newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldBeEqualTo sisteVersjon.tekst
+                newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo sisteVersjon.oppfolgingsgrunn
                 newOppfolgingsoppgave?.isActive shouldBeEqualTo oppfolgingsoppgave.isActive
                 newOppfolgingsoppgave?.removedBy shouldBeEqualTo oppfolgingsoppgave.removedBy
 
-                newOppfolgingsoppgave?.sisteVersjon()?.frist shouldNotBeEqualTo oppfolgingsoppgave.sisteVersjon().frist
+                newOppfolgingsoppgave?.sisteVersjon()?.frist shouldNotBeEqualTo sisteVersjon.frist
                 newOppfolgingsoppgave?.sisteVersjon()?.frist shouldBeEqualTo newFrist
 
                 newOppfolgingsoppgave?.publishedAt.shouldBeNull()
@@ -72,35 +71,39 @@ class OppfolgingsoppgaveServiceSpek : Spek({
         it("adds a new version of oppfolgingsoppgave with only edited tekst") {
             val createdOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
 
-            val newTekst = oppfolgingsoppgave.sisteVersjon().tekst + " - enda mer informasjon her"
+            val sisteVersjon = oppfolgingsoppgave.sisteVersjon()
+            val newTekst = sisteVersjon.tekst + " - enda mer informasjon her"
             val newOppfolgingsoppgave = oppfolgingsoppgaveService.editOppfolgingsoppgave(
                 existingOppfolgingsoppgaveUuid = createdOppfolgingsoppgave.uuid,
                 veilederIdent = UserConstants.OTHER_VEILEDER_IDENT,
+                newOppfolgingsgrunn = sisteVersjon.oppfolgingsgrunn,
                 newTekst = newTekst,
-                newFrist = oppfolgingsoppgave.sisteVersjon().frist,
+                newFrist = sisteVersjon.frist,
             )
 
             newOppfolgingsoppgave?.uuid shouldBeEqualTo oppfolgingsoppgave.uuid
             newOppfolgingsoppgave?.personIdent shouldBeEqualTo oppfolgingsoppgave.personIdent
             newOppfolgingsoppgave?.sisteVersjon()?.createdBy shouldBeEqualTo UserConstants.OTHER_VEILEDER_IDENT
-            newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo oppfolgingsoppgave.sisteVersjon().oppfolgingsgrunn
-            newOppfolgingsoppgave?.sisteVersjon()?.frist shouldBeEqualTo oppfolgingsoppgave.sisteVersjon().frist
+            newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo sisteVersjon.oppfolgingsgrunn
+            newOppfolgingsoppgave?.sisteVersjon()?.frist shouldBeEqualTo sisteVersjon.frist
             newOppfolgingsoppgave?.isActive shouldBeEqualTo oppfolgingsoppgave.isActive
             newOppfolgingsoppgave?.publishedAt shouldBeEqualTo oppfolgingsoppgave.publishedAt
             newOppfolgingsoppgave?.removedBy shouldBeEqualTo oppfolgingsoppgave.removedBy
 
-            newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldNotBeEqualTo oppfolgingsoppgave.sisteVersjon().tekst
+            newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldNotBeEqualTo sisteVersjon.tekst
             newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldBeEqualTo newTekst
             newOppfolgingsoppgave?.publishedAt.shouldBeNull()
         }
         it("adds a new version of oppfolgingsoppgave with edited frist and tekst") {
             val createdOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
 
-            val newTekst = oppfolgingsoppgave.sisteVersjon().tekst + " - enda mer informasjon her"
-            val newFrist = oppfolgingsoppgave.sisteVersjon().frist!!.plusWeeks(1)
+            val sisteVersjon = oppfolgingsoppgave.sisteVersjon()
+            val newTekst = sisteVersjon.tekst + " - enda mer informasjon her"
+            val newFrist = sisteVersjon.frist!!.plusWeeks(1)
             val newOppfolgingsoppgave = oppfolgingsoppgaveService.editOppfolgingsoppgave(
                 existingOppfolgingsoppgaveUuid = createdOppfolgingsoppgave.uuid,
                 veilederIdent = UserConstants.OTHER_VEILEDER_IDENT,
+                newOppfolgingsgrunn = sisteVersjon.oppfolgingsgrunn,
                 newTekst = newTekst,
                 newFrist = newFrist,
             )
@@ -108,18 +111,35 @@ class OppfolgingsoppgaveServiceSpek : Spek({
             newOppfolgingsoppgave?.uuid shouldBeEqualTo oppfolgingsoppgave.uuid
             newOppfolgingsoppgave?.personIdent shouldBeEqualTo oppfolgingsoppgave.personIdent
             newOppfolgingsoppgave?.sisteVersjon()?.createdBy shouldBeEqualTo UserConstants.OTHER_VEILEDER_IDENT
-            newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo oppfolgingsoppgave.sisteVersjon().oppfolgingsgrunn
+            newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo sisteVersjon.oppfolgingsgrunn
             newOppfolgingsoppgave?.isActive shouldBeEqualTo oppfolgingsoppgave.isActive
             newOppfolgingsoppgave?.publishedAt shouldBeEqualTo oppfolgingsoppgave.publishedAt
             newOppfolgingsoppgave?.removedBy shouldBeEqualTo oppfolgingsoppgave.removedBy
 
-            newOppfolgingsoppgave?.sisteVersjon()?.frist shouldNotBeEqualTo oppfolgingsoppgave.sisteVersjon().frist
+            newOppfolgingsoppgave?.sisteVersjon()?.frist shouldNotBeEqualTo sisteVersjon.frist
             newOppfolgingsoppgave?.sisteVersjon()?.frist shouldBeEqualTo newFrist
 
-            newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldNotBeEqualTo oppfolgingsoppgave.sisteVersjon().tekst
+            newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldNotBeEqualTo sisteVersjon.tekst
             newOppfolgingsoppgave?.sisteVersjon()?.tekst shouldBeEqualTo newTekst
 
             newOppfolgingsoppgave?.publishedAt.shouldBeNull()
+        }
+        it("deletes current oppfolgingsoppgave and adds new oppfolgingsoppgave when edited oppfolgingsgrunn") {
+            val createdOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
+
+            val newOppfolgingsoppgave = oppfolgingsoppgaveService.editOppfolgingsoppgave(
+                existingOppfolgingsoppgaveUuid = createdOppfolgingsoppgave.uuid,
+                veilederIdent = VEILEDER_IDENT,
+                newOppfolgingsgrunn = Oppfolgingsgrunn.VURDER_14A,
+                newTekst = oppfolgingsoppgave.sisteVersjon().tekst,
+                newFrist = oppfolgingsoppgave.sisteVersjon().frist,
+            )
+
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgave(uuid = createdOppfolgingsoppgave.uuid)?.isActive?.shouldBeFalse()
+
+            newOppfolgingsoppgave?.uuid shouldNotBeEqualTo createdOppfolgingsoppgave.uuid
+            newOppfolgingsoppgave?.isActive?.shouldBeTrue()
+            newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn shouldBeEqualTo Oppfolgingsgrunn.VURDER_14A
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/huskelapp/cronjob/PublishOppfolgingsoppgaveCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/huskelapp/cronjob/PublishOppfolgingsoppgaveCronjobSpek.kt
@@ -133,11 +133,12 @@ class PublishOppfolgingsoppgaveCronjobSpek : Spek({
             }
         }
         it("publishes edited huskelapp") {
+            val oppfolgingsgrunn = Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE
             val enHuskelapp = Oppfolgingsoppgave.create(
                 personIdent,
                 veilederIdent,
                 tekst = "En oppfolgingsoppgave",
-                oppfolgingsgrunn = Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE
+                oppfolgingsgrunn = oppfolgingsgrunn
             )
             oppfolgingsoppgaveRepository.create(enHuskelapp)
 
@@ -155,6 +156,7 @@ class PublishOppfolgingsoppgaveCronjobSpek : Spek({
             oppfolgingsoppgaveService.editOppfolgingsoppgave(
                 existingOppfolgingsoppgaveUuid = enHuskelapp.uuid,
                 veilederIdent = veilederIdent,
+                newOppfolgingsgrunn = oppfolgingsgrunn,
                 newTekst = newTekst,
                 newFrist = newFrist,
             )


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Tillater endring av oppfølgingsgrunn i eksisterende API for å redigere oppfølgingsoppgave. Dersom oppfølgingsgrunn er endret sletter vi eksisterende oppfølgingsoppgave og lager en ny.
