### PR TITLE
IS-2790: Skip updatedAt when publishing to kafka

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
@@ -285,7 +285,7 @@ private fun DatabaseInterface.getUnpublishedOppfolgingsoppgaver(): List<POppfolg
 
 private const val querySetPublished = """
     UPDATE huskelapp
-    SET published_at = ?, updated_at = ?
+    SET published_at = ?
     WHERE uuid = ?
 """
 
@@ -298,8 +298,7 @@ private fun DatabaseInterface.updatePublished(oppfolgingsoppgave: Oppfolgingsopp
 private fun Connection.updatePublished(oppfolgingsoppgave: Oppfolgingsoppgave) {
     this.prepareStatement(querySetPublished).use {
         it.setObject(1, oppfolgingsoppgave.publishedAt)
-        it.setObject(2, oppfolgingsoppgave.updatedAt)
-        it.setString(3, oppfolgingsoppgave.uuid.toString())
+        it.setString(2, oppfolgingsoppgave.uuid.toString())
         val updated = it.executeUpdate()
         if (updated != 1) {
             throw SQLException("Expected a single row to be updated, got update count $updated")


### PR DESCRIPTION
Dropper oppdatering av `updatedAt` ved publisering på kafka. Siden vi uansett lagrer `publishedAt`-timestamp i den forbindelse virker det unødvendig. I tillegg skaper det problemer når vi skal finne tidspunktet en oppfølgingsoppgave ble fjernet (dersom en oppfølgingsoppgave ikke er aktiv antar vi at `updatedAt` er når den ble fjernet).