### PR TITLE
IS-3096: Handle identhendelser from pdl

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 group = "no.nav.syfo"
 version = "0.0.1"
 
+val confluentVersion = "7.8.0"
 val flyway = "11.3.0"
 val hikari = "6.2.1"
 val jacksonDataType = "2.18.2"
@@ -70,6 +71,22 @@ dependencies {
 
     // (De-)serialization
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataType")
+
+    implementation("io.confluent:kafka-avro-serializer:$confluentVersion", excludeLog4j)
+    constraints {
+        implementation("org.apache.avro:avro") {
+            because("io.confluent:kafka-avro-serializer:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-39410")
+            version {
+                require("1.12.0")
+            }
+        }
+        implementation("org.apache.commons:commons-compress") {
+            because("org.apache.commons:commons-compress:1.22 -> https://www.cve.org/CVERecord?id=CVE-2012-2098")
+            version {
+                require("1.27.1")
+            }
+        }
+    }
 
     // Tests
     testImplementation("io.ktor:ktor-server-test-host:$ktor")

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -6,15 +6,18 @@ import io.ktor.server.config.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import no.nav.syfo.api.apiModule
-import no.nav.syfo.infrastructure.cronjob.cronjobModule
-import no.nav.syfo.infrastructure.database.applicationDatabase
-import no.nav.syfo.infrastructure.database.databaseModule
+import no.nav.syfo.application.OppfolgingsoppgaveService
 import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.infrastructure.client.wellknown.getWellKnown
-import no.nav.syfo.application.OppfolgingsoppgaveService
+import no.nav.syfo.infrastructure.cronjob.cronjobModule
+import no.nav.syfo.infrastructure.database.applicationDatabase
+import no.nav.syfo.infrastructure.database.databaseModule
 import no.nav.syfo.infrastructure.database.repository.OppfolgingsoppgaveRepository
 import no.nav.syfo.infrastructure.kafka.OppfolgingsoppgaveProducer
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseConsumer
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseService
+import no.nav.syfo.infrastructure.kafka.identhendelse.launchIdenthendelseConsumer
 import no.nav.syfo.infrastructure.kafka.oppfolgingsoppgaveKafkaProducer
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
@@ -76,6 +79,15 @@ fun main() {
                 environment = environment,
                 oppfolgingsoppgaveService = oppfolgingsoppgaveService,
                 oppfolgingsoppgaveProducer = oppfolgingsoppgaveProducer,
+            )
+            launchIdenthendelseConsumer(
+                applicationState = applicationState,
+                kafkaEnvironment = environment.kafka,
+                identhendelseConsumer = IdenthendelseConsumer(
+                    identhendelseService = IdenthendelseService(
+                        oppfolgingsoppgaveRepository = oppfolgingsoppgaveRepository,
+                    )
+                ),
             )
 
             monitor.subscribe(ApplicationStarted) {

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -29,6 +29,9 @@ data class Environment(
         aivenKeystoreLocation = getEnvVar("KAFKA_KEYSTORE_PATH"),
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
+        aivenSchemaRegistryUrl = getEnvVar("KAFKA_SCHEMA_REGISTRY"),
+        aivenRegistryUser = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
+        aivenRegistryPassword = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
     ),
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
     val clients: ClientsEnvironment = ClientsEnvironment(

--- a/src/main/kotlin/no/nav/syfo/application/IOppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IOppfolgingsoppgaveRepository.kt
@@ -17,4 +17,5 @@ interface IOppfolgingsoppgaveRepository {
     fun getUnpublished(): List<Oppfolgingsoppgave>
     fun updatePublished(oppfolgingsoppgave: Oppfolgingsoppgave)
     fun updateRemovedOppfolgingsoppgave(oppfolgingsoppgave: Oppfolgingsoppgave)
+    fun updatePersonident(nyPersonident: PersonIdent, oppfolgingsoppgaver: List<Oppfolgingsoppgave>)
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
@@ -118,6 +118,22 @@ class OppfolgingsoppgaveRepository(
     override fun updateRemovedOppfolgingsoppgave(oppfolgingsoppgave: Oppfolgingsoppgave) =
         database.updateRemovedOppfolgingsoppgave(oppfolgingsoppgave = oppfolgingsoppgave)
 
+    override fun updatePersonident(nyPersonident: PersonIdent, oppfolgingsoppgaver: List<Oppfolgingsoppgave>) {
+        database.connection.use { connection ->
+            connection.prepareStatement(UPDATE_OPPFOLGINGSOPPGAVE_PERSONIDENT).use {
+                oppfolgingsoppgaver.forEach { oppfolgingsoppgave ->
+                    it.setString(1, nyPersonident.value)
+                    it.setString(2, oppfolgingsoppgave.uuid.toString())
+                    val updated = it.executeUpdate()
+                    if (updated != 1) {
+                        throw SQLException("Expected a single row to be updated, got update count $updated")
+                    }
+                }
+            }
+            connection.commit()
+        }
+    }
+
     companion object {
         private const val CREATE_OPPFOLGINGSOPPGAVE_VERSJON_QUERY =
             """
@@ -133,6 +149,13 @@ class OppfolgingsoppgaveRepository(
                 latest
             ) values (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING *
+            """
+
+        private const val UPDATE_OPPFOLGINGSOPPGAVE_PERSONIDENT =
+            """
+            UPDATE huskelapp
+            SET personident = ?
+            WHERE uuid = ?
             """
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConfig.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.infrastructure.kafka
 
 import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
 import java.util.*
 
@@ -19,6 +21,22 @@ inline fun <reified Serializer> kafkaAivenProducerConfig(
         this[ProducerConfig.RETRIES_CONFIG] = "100000"
         this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.canonicalName
         this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = Serializer::class.java.canonicalName
+    }
+}
+
+inline fun <reified Deserializer> kafkaAivenConsumerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(kafkaEnvironment))
+
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "ishuskelapp-v1"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false" // we commit manually if db persistence is successful
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
+        this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = Deserializer::class.java.canonicalName
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerService.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.infrastructure.kafka
+
+import org.apache.kafka.clients.consumer.KafkaConsumer
+
+interface KafkaConsumerService<ConsumerRecordValue> {
+    val pollDurationInMillis: Long
+    suspend fun pollAndProcessRecords(
+        kafkaConsumer: KafkaConsumer<String, ConsumerRecordValue>,
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerTask.kt
@@ -1,0 +1,32 @@
+package no.nav.syfo.infrastructure.kafka
+
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.launchBackgroundTask
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.*
+
+val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+inline fun <reified ConsumerRecordValue> launchKafkaConsumer(
+    applicationState: ApplicationState,
+    topic: String,
+    consumerProperties: Properties,
+    kafkaConsumerService: KafkaConsumerService<ConsumerRecordValue>,
+) {
+    launchBackgroundTask(
+        applicationState = applicationState
+    ) {
+        log.info("Setting up kafka consumer for ${ConsumerRecordValue::class.java.simpleName}")
+
+        val kafkaConsumer = KafkaConsumer<String, ConsumerRecordValue>(consumerProperties)
+
+        while (applicationState.ready) {
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(topic))
+            }
+            kafkaConsumerService.pollAndProcessRecords(kafkaConsumer)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaEnvironment.kt
@@ -6,4 +6,7 @@ class KafkaEnvironment(
     val aivenTruststoreLocation: String,
     val aivenSecurityProtocol: String,
     val aivenBootstrapServers: String,
+    val aivenSchemaRegistryUrl: String,
+    val aivenRegistryUser: String,
+    val aivenRegistryPassword: String,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
@@ -1,35 +1,20 @@
 package no.nav.syfo.infrastructure.kafka.identhendelse
 
-import kotlinx.coroutines.delay
 import no.nav.syfo.infrastructure.kafka.KafkaConsumerService
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 class IdenthendelseConsumer(private val identhendelseService: IdenthendelseService) : KafkaConsumerService<GenericRecord> {
     override val pollDurationInMillis: Long = 1000
 
     override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
-        runCatching {
-            val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
-            if (records.count() > 0) {
-                records.mapNotNull { it.value() }.forEach {
-                    identhendelseService.handle(identhendelse = it.toKafkaIdenthendelseDTO())
-                }
-                kafkaConsumer.commitSync()
+        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            records.mapNotNull { it.value() }.forEach {
+                identhendelseService.handle(identhendelse = it.toKafkaIdenthendelseDTO())
             }
-        }.onFailure { ex ->
-            log.warn("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
-            kafkaConsumer.unsubscribe()
-            delay(DELAY_ON_ERROR_SECONDS.seconds)
+            kafkaConsumer.commitSync()
         }
-    }
-
-    companion object {
-        private const val DELAY_ON_ERROR_SECONDS = 60L
-        private val log: Logger = LoggerFactory.getLogger(this::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import kotlinx.coroutines.delay
+import no.nav.syfo.infrastructure.kafka.KafkaConsumerService
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class IdenthendelseConsumer(private val identhendelseService: IdenthendelseService) : KafkaConsumerService<GenericRecord> {
+    override val pollDurationInMillis: Long = 1000
+
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
+        runCatching {
+            val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+            if (records.count() > 0) {
+                records.mapNotNull { it.value() }.forEach {
+                    identhendelseService.handle(identhendelse = it.toKafkaIdenthendelseDTO())
+                }
+                kafkaConsumer.commitSync()
+            }
+        }.onFailure { ex ->
+            log.warn("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
+            kafkaConsumer.unsubscribe()
+            delay(DELAY_ON_ERROR_SECONDS.seconds)
+        }
+    }
+
+    companion object {
+        private const val DELAY_ON_ERROR_SECONDS = 60L
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
+import no.nav.syfo.infrastructure.kafka.kafkaAivenConsumerConfig
+import no.nav.syfo.infrastructure.kafka.launchKafkaConsumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import java.util.*
+
+const val PDL_AKTOR_TOPIC = "pdl.aktor-v2"
+
+fun launchIdenthendelseConsumer(
+    applicationState: ApplicationState,
+    kafkaEnvironment: KafkaEnvironment,
+    identhendelseConsumer: IdenthendelseConsumer,
+) {
+    val consumerProperties = Properties().apply {
+        putAll(kafkaAivenConsumerConfig<KafkaAvroDeserializer>(kafkaEnvironment))
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
+
+        this[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = kafkaEnvironment.aivenSchemaRegistryUrl
+        this[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = false
+        this[KafkaAvroDeserializerConfig.USER_INFO_CONFIG] =
+            "${kafkaEnvironment.aivenRegistryUser}:${kafkaEnvironment.aivenRegistryPassword}"
+        this[KafkaAvroDeserializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE] = "USER_INFO"
+    }
+
+    launchKafkaConsumer(
+        applicationState = applicationState,
+        topic = PDL_AKTOR_TOPIC,
+        consumerProperties = consumerProperties,
+        kafkaConsumerService = identhendelseConsumer
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.ApplicationState
 import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
 import no.nav.syfo.infrastructure.kafka.kafkaAivenConsumerConfig
 import no.nav.syfo.infrastructure.kafka.launchKafkaConsumer
-import org.apache.kafka.clients.consumer.ConsumerConfig
 import java.util.*
 
 const val PDL_AKTOR_TOPIC = "pdl.aktor-v2"
@@ -18,8 +17,6 @@ fun launchIdenthendelseConsumer(
 ) {
     val consumerProperties = Properties().apply {
         putAll(kafkaAivenConsumerConfig<KafkaAvroDeserializer>(kafkaEnvironment))
-        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
-
         this[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = kafkaEnvironment.aivenSchemaRegistryUrl
         this[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = false
         this[KafkaAvroDeserializerConfig.USER_INFO_CONFIG] =

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseService.kt
@@ -1,0 +1,29 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import no.nav.syfo.infrastructure.database.repository.OppfolgingsoppgaveRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class IdenthendelseService(private val oppfolgingsoppgaveRepository: OppfolgingsoppgaveRepository) {
+
+    fun handle(identhendelse: KafkaIdenthendelseDTO) {
+        val (aktivIdent, inaktiveIdenter) = identhendelse.getFolkeregisterIdenter()
+        if (aktivIdent != null) {
+            val oppfolgingsoppgaverMedInaktivIdent = inaktiveIdenter.flatMap { oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(it) }
+
+            if (oppfolgingsoppgaverMedInaktivIdent.isNotEmpty()) {
+                oppfolgingsoppgaveRepository.updatePersonident(
+                    nyPersonident = aktivIdent,
+                    oppfolgingsoppgaver = oppfolgingsoppgaverMedInaktivIdent,
+                )
+                log.info("Identhendelse: Updated ${oppfolgingsoppgaverMedInaktivIdent.size} oppfølgingsoppgaver based on Identhendelse from PDL")
+            }
+        } else {
+            log.warn("Identhendelse ignored - Mangler aktiv ident i PDL")
+        }
+    }
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/KafkaIdenthendelseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/KafkaIdenthendelseDTO.kt
@@ -1,0 +1,46 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import no.nav.syfo.domain.PersonIdent
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericRecord
+
+// Basert på https://github.com/navikt/pdl/blob/master/libs/contract-pdl-avro/src/main/avro/no/nav/person/pdl/aktor/AktorV2.avdl
+
+data class KafkaIdenthendelseDTO(
+    val identifikatorer: List<Identifikator>,
+)
+
+data class Identifikator(
+    val idnummer: String,
+    val type: IdentType,
+    val gjeldende: Boolean,
+)
+
+enum class IdentType {
+    FOLKEREGISTERIDENT,
+    AKTORID,
+    NPID,
+}
+
+fun KafkaIdenthendelseDTO.getFolkeregisterIdenter(): Pair<PersonIdent?, List<PersonIdent>> {
+    val (aktive, inaktive) = identifikatorer.filter { it.type == IdentType.FOLKEREGISTERIDENT }.partition { it.gjeldende }
+    val aktivIdent = aktive.firstOrNull()?.let { PersonIdent(it.idnummer) }
+
+    return Pair(aktivIdent, inaktive.map { PersonIdent(it.idnummer) })
+}
+
+fun GenericRecord.toKafkaIdenthendelseDTO(): KafkaIdenthendelseDTO {
+    val identifikatorer = (get("identifikatorer") as GenericData.Array<GenericRecord>).map {
+        Identifikator(
+            idnummer = it.get("idnummer").toString(),
+            gjeldende = it.get("gjeldende").toString().toBoolean(),
+            type = when (it.get("type").toString()) {
+                "FOLKEREGISTERIDENT" -> IdentType.FOLKEREGISTERIDENT
+                "AKTORID" -> IdentType.AKTORID
+                "NPID" -> IdentType.NPID
+                else -> throw IllegalStateException("Har mottatt ident med ukjent type")
+            }
+        )
+    }
+    return KafkaIdenthendelseDTO(identifikatorer)
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseServiceSpek.kt
@@ -1,0 +1,88 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import no.nav.syfo.domain.Oppfolgingsgrunn
+import no.nav.syfo.domain.Oppfolgingsoppgave
+import no.nav.syfo.infrastructure.database.repository.OppfolgingsoppgaveRepository
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generator.generateIdenthendelse
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldNotBeEmpty
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+private val aktivIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
+private val inaktivIdent = UserConstants.ARBEIDSTAKER_3_PERSONIDENT
+
+class IdenthendelseServiceSpek : Spek({
+    describe(IdenthendelseService::class.java.simpleName) {
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+        val oppfolgingsoppgaveRepository = OppfolgingsoppgaveRepository(database = database)
+        val identhendelseService = IdenthendelseService(
+            oppfolgingsoppgaveRepository = oppfolgingsoppgaveRepository,
+        )
+
+        beforeEachTest {
+            database.dropData()
+        }
+
+        val oppfolgingsoppgaveInaktivIdent = Oppfolgingsoppgave.create(
+            personIdent = inaktivIdent,
+            veilederIdent = UserConstants.VEILEDER_IDENT,
+            tekst = "En god tekst for en oppfolgingsoppgave",
+            oppfolgingsgrunn = Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT,
+        )
+
+        it("Flytter oppfølgingsoppgave fra inaktiv ident til ny ident når person får ny ident") {
+            oppfolgingsoppgaveRepository.create(oppfolgingsoppgave = oppfolgingsoppgaveInaktivIdent)
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = listOf(inaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = inaktivIdent).shouldBeEmpty()
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = aktivIdent).shouldNotBeEmpty()
+        }
+
+        it("Oppdaterer ingenting når person får ny ident og uten oppfølgingsoppgave på inaktiv ident") {
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = listOf(inaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = inaktivIdent).shouldBeEmpty()
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = aktivIdent).shouldBeEmpty()
+        }
+
+        it("Oppdaterer ingenting når person får ny ident uten inaktiv identer") {
+            oppfolgingsoppgaveRepository.create(oppfolgingsoppgave = oppfolgingsoppgaveInaktivIdent)
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = emptyList()
+            )
+            identhendelseService.handle(identhendelse)
+
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = inaktivIdent).shouldNotBeEmpty()
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = aktivIdent).shouldBeEmpty()
+        }
+
+        it("Oppdaterer ingenting når person mangler aktiv ident") {
+            oppfolgingsoppgaveRepository.create(oppfolgingsoppgave = oppfolgingsoppgaveInaktivIdent)
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = null,
+                inaktiveIdenter = listOf(inaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = inaktivIdent).shouldNotBeEmpty()
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent = aktivIdent).shouldBeEmpty()
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -28,6 +28,9 @@ fun testEnvironment() = Environment(
         aivenKeystoreLocation = "keystore",
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = "truststore",
+        aivenSchemaRegistryUrl = "http://kafka-schema-registry.tpa.svc.nais.local:8081",
+        aivenRegistryUser = "registryuser",
+        aivenRegistryPassword = "registrypassword",
     ),
     electorPath = "electorPath",
     clients = ClientsEnvironment(

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/IdenthendelseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/IdenthendelseGenerator.kt
@@ -1,0 +1,18 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdentType
+import no.nav.syfo.infrastructure.kafka.identhendelse.Identifikator
+import no.nav.syfo.infrastructure.kafka.identhendelse.KafkaIdenthendelseDTO
+
+fun generateIdenthendelse(
+    aktivIdent: PersonIdent?,
+    inaktiveIdenter: List<PersonIdent>
+): KafkaIdenthendelseDTO {
+    val identifikatorer = inaktiveIdenter.map { Identifikator(idnummer = it.value, gjeldende = false, type = IdentType.FOLKEREGISTERIDENT) }.toMutableList()
+    aktivIdent?.let { identifikatorer.add(Identifikator(idnummer = it.value, gjeldende = true, type = IdentType.FOLKEREGISTERIDENT)) }
+
+    return KafkaIdenthendelseDTO(
+        identifikatorer = identifikatorer
+    )
+}


### PR DESCRIPTION
Leser inn alle identhendelser fra PDL og flytter oppfølgingsoppgaver til ny (aktiv) ident der hvor det forekommer oppfølgingsoppgaver på inaktiv ident.
Koden for kafka-consumer osv er hovedsakelig copy-paste fra andre apper hvor vi har tilsvarende opplegg.
