### PR TITLE
IS-3367: Partiell indeks for publiserings-cronjobben

### DIFF
--- a/src/main/resources/db/migration/V2_5__partial_index.sql
+++ b/src/main/resources/db/migration/V2_5__partial_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IX_HUSKELAPP_UNPUBLISHED on HUSKELAPP (personident, created_at) WHERE published_at IS NULL;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Cronjob'en som publiserer huskelapper kjører hvert 20 sekund og gjør en ganske tung spørring for å finne upubliserte huskelapper. Dette kan forbedres vesentlig med en partiell indeks.