### PR TITLE
IS-3927: Fix duplicate task issues

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt
@@ -16,8 +16,7 @@ class OppfolgingsoppgaveService(
 ) {
     fun getActiveOppfolgingsoppgave(personIdent: PersonIdent): Oppfolgingsoppgave? =
         oppfolgingsoppgaveRepository.getOppfolgingsoppgaver(personIdent)
-            .firstOrNull()
-            ?.takeIf { it.isActive }
+            .lastOrNull { it.isActive }
 
     fun getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<Oppfolgingsoppgave> =
         oppfolgingsoppgaveRepository.getActiveOppfolgingsoppgaver(personidenter)

--- a/src/main/kotlin/no/nav/syfo/domain/Oppfolgingsoppgave.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Oppfolgingsoppgave.kt
@@ -46,7 +46,7 @@ data class Oppfolgingsoppgave private constructor(
         )
     }
 
-    fun sisteVersjon() = versjoner.first()
+    fun sisteVersjon() = versjoner.single { it.latest }
 
     companion object {
         fun create(

--- a/src/main/kotlin/no/nav/syfo/domain/OppfolgingsoppgaveVersjon.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/OppfolgingsoppgaveVersjon.kt
@@ -12,6 +12,7 @@ data class OppfolgingsoppgaveVersjon private constructor(
     val tekst: String?,
     val oppfolgingsgrunn: Oppfolgingsgrunn,
     val frist: LocalDate?,
+    val latest: Boolean,
 ) {
     fun edit(
         tekst: String?,
@@ -47,6 +48,7 @@ data class OppfolgingsoppgaveVersjon private constructor(
                 tekst = tekst,
                 oppfolgingsgrunn = oppfolgingsgrunn,
                 frist = frist,
+                latest = true,
             )
         }
 
@@ -57,6 +59,7 @@ data class OppfolgingsoppgaveVersjon private constructor(
             tekst: String?,
             oppfolgingsgrunn: String,
             frist: LocalDate?,
+            latest: Boolean,
         ) = OppfolgingsoppgaveVersjon(
             uuid = uuid,
             createdAt = createdAt,
@@ -64,6 +67,7 @@ data class OppfolgingsoppgaveVersjon private constructor(
             tekst = tekst,
             oppfolgingsgrunn = Oppfolgingsgrunn.valueOf(oppfolgingsgrunn),
             frist = frist,
+            latest = latest,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/OppfolgingsoppgaveRepository.kt
@@ -98,7 +98,7 @@ class OppfolgingsoppgaveRepository(
             it.setStringOrNull(5, newVersjon.tekst)
             it.setStringOrNull(6, newVersjon.oppfolgingsgrunn.toString())
             it.setDateOrNull(7, newVersjon.frist?.let { date -> Date.valueOf(date) })
-            it.setBoolean(8, true)
+            it.setBoolean(8, newVersjon.latest)
             it.executeQuery().toList { toPOppfolgingsoppgaveVersjon() }
         }
 
@@ -213,7 +213,7 @@ private const val queryGetOppfolgingsoppgaveByPersonIdent = """
     SELECT *
     FROM HUSKELAPP
     WHERE personident = ?
-    ORDER BY created_at DESC
+    ORDER BY created_at ASC
 """
 
 private fun DatabaseInterface.getOppfolgingsoppgaver(personIdent: PersonIdent): List<POppfolgingsoppgave> {
@@ -247,6 +247,7 @@ private const val queryGetActiveOppfolgingsoppgaverByPersonident = """
     FROM HUSKELAPP h
     INNER JOIN HUSKELAPP_VERSJON hv ON (h.id = hv.huskelapp_id AND hv.latest)
     WHERE h.personident = ANY (string_to_array(?, ',')) AND h.is_active = true
+    ORDER BY created_at ASC
 """
 
 private fun DatabaseInterface.getActiveOppfolgingsoppgaver(personidenter: List<PersonIdent>): List<Oppfolgingsoppgave> {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/POppfolgingsoppgaveVersjon.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/POppfolgingsoppgaveVersjon.kt
@@ -23,7 +23,8 @@ data class POppfolgingsoppgaveVersjon(
             createdBy = createdBy,
             tekst = tekst,
             oppfolgingsgrunn = oppfolgingsgrunner.first(),
-            frist = frist
+            frist = frist,
+            latest = latest,
         )
     }
 }

--- a/src/test/kotlin/no/nav/syfo/application/OppfolgingsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/OppfolgingsoppgaveServiceTest.kt
@@ -137,10 +137,33 @@ class OppfolgingsoppgaveServiceTest {
             newFrist = oppfolgingsoppgave.sisteVersjon().frist,
         )
 
-        assertFalse(oppfolgingsoppgaveRepository.getOppfolgingsoppgave(uuid = createdOppfolgingsoppgave.uuid)?.isActive ?: true)
+        assertFalse(
+            oppfolgingsoppgaveRepository.getOppfolgingsoppgave(uuid = createdOppfolgingsoppgave.uuid)?.isActive ?: true
+        )
 
         assertNotEquals(createdOppfolgingsoppgave.uuid, newOppfolgingsoppgave?.uuid)
         assertTrue(newOppfolgingsoppgave?.isActive ?: false)
         assertEquals(Oppfolgingsgrunn.VURDER_14A, newOppfolgingsoppgave?.sisteVersjon()?.oppfolgingsgrunn)
+    }
+
+    @Test
+    fun `getActiveOppfolgingsoppgave returns last oppfolgingsoppgave when multiple exists`() {
+        val firstOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(oppfolgingsoppgave)
+
+        val secondOppfolgingsoppgave = oppfolgingsoppgaveRepository.create(
+            Oppfolgingsoppgave.create(
+                personIdent = ARBEIDSTAKER_PERSONIDENT,
+                veilederIdent = UserConstants.OTHER_VEILEDER_IDENT,
+                tekst = "Nyere oppfolgingsoppgave",
+                oppfolgingsgrunn = Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT,
+                frist = LocalDate.now().plusDays(2),
+            ),
+        )
+
+        val result = oppfolgingsoppgaveService.getActiveOppfolgingsoppgave(ARBEIDSTAKER_PERSONIDENT)
+
+        assertNotNull(result)
+        assertEquals(secondOppfolgingsoppgave.uuid, result?.uuid)
+        assertNotEquals(firstOppfolgingsoppgave.uuid, result?.uuid)
     }
 }

--- a/src/test/kotlin/no/nav/syfo/huskelapp/api/OppfolgingsoppgaveApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/huskelapp/api/OppfolgingsoppgaveApiTest.kt
@@ -213,7 +213,7 @@ class OppfolgingsoppgaveApiTest {
 
                 assertEquals(2, responseDTO.size)
 
-                val sisteOppfolgingsoppgave = responseDTO[0]
+                val sisteOppfolgingsoppgave = responseDTO.last()
                 val sisteVersjon = sisteOppfolgingsoppgave.versjoner.first()
 
                 assertEquals(ARBEIDSTAKER_PERSONIDENT, sisteOppfolgingsoppgave.personIdent)
@@ -225,7 +225,7 @@ class OppfolgingsoppgaveApiTest {
                 assertEquals(Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE, sisteVersjon.oppfolgingsgrunn)
                 assertEquals("Oppfølgingsoppgave nr. 2", sisteVersjon.tekst)
 
-                val forsteOppfolgingsoppgave = responseDTO[1]
+                val forsteOppfolgingsoppgave = responseDTO.first()
                 val forsteVersjon = forsteOppfolgingsoppgave.versjoner.first()
 
                 assertEquals(ARBEIDSTAKER_PERSONIDENT, forsteOppfolgingsoppgave.personIdent)
@@ -585,12 +585,12 @@ class OppfolgingsoppgaveApiTest {
                     val responseDTOs = response.body<List<OppfolgingsoppgaveResponseDTO>>()
                     assertEquals(2, responseDTOs.size)
 
-                    val aktivOppfolgingsoppgave = responseDTOs.first()
+                    val aktivOppfolgingsoppgave = responseDTOs.last()
                     assertTrue(aktivOppfolgingsoppgave.isActive)
                     assertEquals(1, aktivOppfolgingsoppgave.versjoner.size)
                     assertEquals(Oppfolgingsgrunn.SAMTALE_MED_BRUKER, aktivOppfolgingsoppgave.versjoner.first().oppfolgingsgrunn)
 
-                    val inaktivOppfolgingsoppgave = responseDTOs.last()
+                    val inaktivOppfolgingsoppgave = responseDTOs.first()
                     assertFalse(inaktivOppfolgingsoppgave.isActive)
                     assertEquals(1, inaktivOppfolgingsoppgave.versjoner.size)
                     assertEquals(Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE, inaktivOppfolgingsoppgave.versjoner.first().oppfolgingsgrunn)


### PR DESCRIPTION
Det kom inn en [Jira-sak](https://jira.adeo.no/browse/FAGSYSTEM-427700) hvor en veileder ser én oppgave på oversiktssiden og en annen på personsiden. Årsaken er at det ligger to aktive oppfølgingsoppgaver på denne personen. Dette ble et lite kaninhull for meg hvor jeg fant et par feil og et par potensielle, fremtidige feil.

**Fikses i denne PRen:**
* Oversiktssiden og personsiden _kan_ vise forskjellig oppgave hvis man har to aktive oppgaver. Dette skal egentlig ikke skje, men det er fikset. Årsaken til at feilen er sporadisk er [bruken av .associate()](https://github.com/navikt/ishuskelapp/blob/a286c721ce946c3547547e8f305b9080e8e2be6d/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsoppgaveApi.kt#L173) når listen man henter fra databasen er usortert og dermed kan havne i vilkårlig rekkefølge. Ved å legge til `ORDER BY created_at ASC` vil man alltid vise siste oppgave.
* Man kan havne i en state hvor en aktiv oppgave ikke vises på personsiden. Dette er fikset på tilsvarende måte [her](https://github.com/navikt/ishuskelapp/blob/a286c721ce946c3547547e8f305b9080e8e2be6d/src/main/kotlin/no/nav/syfo/application/OppfolgingsoppgaveService.kt#L19).
* Drar også ut `.latest` fra `OppfolgingsoppgaveVersjon` til domenet og bruker dette i stedet for `versjoner.first()`, som i prinsippet kan føre til lignende feil i fremtiden.

**Fikses ikke i denne PRen:**
* APIet tillater at man oppretter flere aktive oppgaver. Med de fiksene denne PRen tar inn, vil dette kun være mulig om to veiledere oppretter oppgave på samme person samtidig. Dette bør vi enten ha validering på, eller så bør en opprettet oppgave overskrive forrige aktive oppgave (litt som man gjør med versjoner). Stemmer for validering.
  * Dette blir en egen oppgave.

**NB:** Jeg sjekket i databasen og ser at 32 personer har per nå flere aktive oppgaver på seg. Selv om denne PRen fikser _visningen_ til slike cases, bør dette fikses i databasen med SQL før PRen merges.